### PR TITLE
remove publish_to: none

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,8 +4,6 @@ version: 0.0.1
 homepage: "https://ditto.live"
 repository: https://github.com/getditto/ditto_flutter_tools
 
-publish_to: none  # remove this once todo in readme is fixed
-
 environment:
   sdk: '>=3.4.0 <4.0.0'
   flutter: ">=1.17.0"


### PR DESCRIPTION
I've published the SDK, but the only change was that this flag was removed (I added it to prevent myself from publishing while the "todo" comment was in the readme, but otherwise it's the same). The correct commit is tagged `v0.0.1`