### PR TITLE
Add missing export in the Sync Status tool for the SyncStatus type

### DIFF
--- a/lib/ditto_flutter_tools.dart
+++ b/lib/ditto_flutter_tools.dart
@@ -2,4 +2,4 @@
 // export "src/disk_usage/disk_usage.dart" show DiskUsage;
 // export "src/log_level_switch.dart" show LogLevelSwitch;
 export "src/sync_status_view.dart" show SyncStatusView;
-export "src/sync_status_helper.dart" show SyncStatusHelper;
+export "src/sync_status_helper.dart" show SyncStatusHelper, SyncStatus;


### PR DESCRIPTION
Adds a missing `export` to make the SyncStatus tool fully usable by customers